### PR TITLE
Issue#24 - Add update flag to set-env command

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,10 @@ Usage: `cli set-env [OPTIONS]`
 
 Options:
 
-    -f, --file TEXT  File to load env vars from
+    -f, --file          TEXT  File to load env vars from
     -sn, --service-name TEXT  Render service name
-    --help           Show this message and exit.
+    -u, --update              flag to indicate it env vars should be overwritten or updated
+    --help                    Show this message and exit.
 
 ![set_envs!](./assets/set_envs.gif "set envs")
 

--- a/src/render_cli/console.py
+++ b/src/render_cli/console.py
@@ -11,6 +11,7 @@ from render_cli.output.services_output import (
     output_env_vars_as_table,
     output_services_as_table,
 )
+from render_cli.utils import convert_env_var_file
 import render_cli.render_services as rs
 from . import __version__
 
@@ -88,15 +89,7 @@ def set_env(file, service_name) -> Any:
         service_name: name of service to set env vars for.
 
     """
-    env_vars = []
-    with open(file) as f:
-        for line in f:
-            line = line.strip()
-            if not line or line.startswith("#"):
-                continue
-            else:
-                var, value = line.split("=")
-                env_vars.append({"key": var.strip(), "value": value.strip()})
+    env_vars = convert_env_var_file(file)
     rs.set_env_variables_for_service(service_name, env_vars)
 
 

--- a/src/render_cli/render_services.py
+++ b/src/render_cli/render_services.py
@@ -39,17 +39,18 @@ def create_headers(is_post: bool = False) -> dict[str, str]:
     return headers
 
 
-def retrieve_env_from_render(service_name) -> Any:
+def retrieve_env_from_render(service_id: str, limit: int = 20) -> Any:
     """Gets environment variables for the specified service.
 
     Args:
-        service_name: name of service to fetch the environment variables for.
+        service_id: id service to fetch the environment variables for.
+        limit: number of env vars to fetch. Defaults to 20.
 
     Returns:
         A list of environment variables for a given service.
 
     """
-    url = f"{RENDER_API_BASE_URL}/{service_name}/env-vars?limit=20"
+    url = f"{RENDER_API_BASE_URL}/{service_id}/env-vars?limit={limit}"
     with requests.get(url, headers=create_headers()) as response:
         try:
             response.raise_for_status()
@@ -58,18 +59,17 @@ def retrieve_env_from_render(service_name) -> Any:
             return handle_errors(exc.response.status_code)
 
 
-def set_env_variables_for_service(service_name: str, env_vars) -> Any:
+def set_env_variables_for_service(service_id: str, env_vars: list[dict]) -> Any:
     """Sets the environment variables for the specified service.
 
     Args:
-        service_name: name of service to set env vars for.
+        service_id: id of service to set vars for.
         env_vars: list of environment variables
 
     Returns:
         nothing
 
     """
-    service_id = find_service_by_name(service_name)["service"]["id"]
     url = f"{RENDER_API_BASE_URL}/{service_id}/env-vars"
     payload = env_vars
     with requests.put(url, headers=create_headers(True), json=payload) as response:

--- a/src/render_cli/utils.py
+++ b/src/render_cli/utils.py
@@ -1,0 +1,12 @@
+def convert_env_var_file(env_var_file_name):
+    """Converts env file into key value for sending to Render."""
+    env_vars = []
+    with open(env_var_file_name) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            else:
+                var, value = line.split("=")
+                env_vars.append({"key": var.strip(), "value": value.strip()})
+    return env_vars

--- a/src/render_cli/utils.py
+++ b/src/render_cli/utils.py
@@ -1,6 +1,9 @@
-def convert_env_var_file(env_var_file_name):
+"""Utility for dealing with env vars."""
+
+
+def convert_env_var_file(env_var_file_name: str) -> dict:
     """Converts env file into key value for sending to Render."""
-    env_vars = []
+    env_vars_from_file = {}
     with open(env_var_file_name) as f:
         for line in f:
             line = line.strip()
@@ -8,5 +11,22 @@ def convert_env_var_file(env_var_file_name):
                 continue
             else:
                 var, value = line.split("=")
-                env_vars.append({"key": var.strip(), "value": value.strip()})
-    return env_vars
+                env_vars_from_file[var.strip()] = value.strip()
+    return env_vars_from_file
+
+
+def convert_from_render_env_format(env_vars) -> dict:
+    """Converts json response from env vars to dict of env vars."""
+    evs = {}
+    for env_var in env_vars:
+        ev = env_var["envVar"]
+        evs[ev["key"]] = ev["value"]
+    return evs
+
+
+def convert_to_render_env_format(env_vars: dict) -> list[dict]:
+    """Converts a dict to a list[dict] with format for render api."""
+    results = []
+    for key, value in env_vars.items():
+        results.append({"key": key, "value": value})
+    return results

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -80,3 +80,14 @@ class TestConsole:
                 console.cli, ["list-env", "-sn", "test-service-name"]
             )
             assert result.exit_code == 0
+
+    def test_set_env_command(self, runner):
+        """Test console cli call to set env vars for a service."""
+        with patch("render_cli.utils") as mock_utils:
+            mock_utils.convert_env_var_file.return_value = (
+                test_constants.test_env_var_key_pairs
+            )
+            with patch("render_cli.console.rs") as mock_render_services:
+                mock_render_services.set_env_variables_for_service.return_value = ""
+                result = runner.invoke(console.cli, ["set-env", "-sn", "test-service-name", "-f", "envfile.txt"])
+                assert result.exit_code == 0

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -66,7 +66,7 @@ class TestConsole:
                 test_constants.test_svc_1
             )
             mock_render_services.retrieve_env_from_render.return_value = (
-                test_constants.test_env_vars
+                test_constants.test_render_env_vars
             )
 
             # test verbose mode
@@ -84,10 +84,17 @@ class TestConsole:
     def test_set_env_command(self, runner):
         """Test console cli call to set env vars for a service."""
         with patch("render_cli.utils") as mock_utils:
-            mock_utils.convert_env_var_file.return_value = (
-                test_constants.test_env_var_key_pairs
-            )
+            mock_utils.convert_env_var_file.return_value = test_constants.test_env_vars
             with patch("render_cli.console.rs") as mock_render_services:
+                mock_render_services.find_service_by_name.return_value = (
+                    test_constants.test_svc_1
+                )
+                mock_render_services.retrieve_env_from_render.return_value = (
+                    test_constants.test_render_env_vars
+                )
                 mock_render_services.set_env_variables_for_service.return_value = ""
-                result = runner.invoke(console.cli, ["set-env", "-sn", "test-service-name", "-f", "envfile.txt"])
+                result = runner.invoke(
+                    console.cli,
+                    ["set-env", "-sn", "test-service-name", "-f", "envfile.txt"],
+                )
                 assert result.exit_code == 0

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,5 +1,5 @@
 """Test cases for the console module."""
-from unittest.mock import patch
+from unittest.mock import mock_open, patch
 
 import click.testing
 import pytest
@@ -83,18 +83,32 @@ class TestConsole:
 
     def test_set_env_command(self, runner):
         """Test console cli call to set env vars for a service."""
-        with patch("render_cli.utils") as mock_utils:
-            mock_utils.convert_env_var_file.return_value = test_constants.test_env_vars
-            with patch("render_cli.console.rs") as mock_render_services:
-                mock_render_services.find_service_by_name.return_value = (
-                    test_constants.test_svc_1
-                )
-                mock_render_services.retrieve_env_from_render.return_value = (
-                    test_constants.test_render_env_vars
-                )
-                mock_render_services.set_env_variables_for_service.return_value = ""
-                result = runner.invoke(
-                    console.cli,
-                    ["set-env", "-sn", "test-service-name", "-f", "envfile.txt"],
-                )
-                assert result.exit_code == 0
+        with patch("os.path.isfile") as mock_isfile:
+            mock_isfile.return_value = True
+            file_data = mock_open(read_data=test_constants.test_file_with_comments)
+            with patch("render_cli.utils.open", file_data):
+                with patch("render_cli.utils") as mock_utils:
+                    mock_utils.convert_env_var_file.return_value = (
+                        test_constants.test_env_vars
+                    )
+                    with patch("render_cli.console.rs") as mock_render_services:
+                        mock_render_services.find_service_by_name.return_value = (
+                            test_constants.test_svc_1
+                        )
+                        mock_render_services.retrieve_env_from_render.return_value = (
+                            test_constants.test_render_env_vars
+                        )
+                        mock_render_services.set_env_variables_for_service.return_value = (
+                            ""
+                        )
+                        result = runner.invoke(
+                            console.cli,
+                            [
+                                "set-env",
+                                "-sn",
+                                "test-service-name",
+                                "-f",
+                                "envfile.txt",
+                            ],
+                        )
+                        assert result.exit_code == 0

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -111,3 +111,10 @@ retrieve_env_vars_failed_with_401 = responses.Response(
     url=f"{RENDER_API_BASE_URL}/service-id/env-vars",
     status=401,
 )
+
+test_env_var_key_pairs = [
+    {"key": "key1", "value": "value1"},
+    {"key": "key2", "value": "value2"},
+    {"key": "key3", "value": "value3"},
+    {"key": "key4", "value": "value4"},
+]

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -97,12 +97,19 @@ test_env_var_4 = {
     "cursor": "nRitXfSIHIpzaWhhNmdkdjMzYXViODhn",
 }
 
-test_env_vars = [test_env_var_1, test_env_var_2, test_env_var_3, test_env_var_4]
+test_render_env_vars = [test_env_var_1, test_env_var_2, test_env_var_3, test_env_var_4]
+
+test_env_var_dict = {
+    "APP_VER": "deadball-player-generator.pr41",
+    "APP_NAME": "deadball-player-generator",
+    "PYTHON_VERSION": "3.10.6",
+    "TEST_ID": "123456",
+}
 
 retrieve_env_vars_response = responses.Response(
     method="GET",
     url=f"{RENDER_API_BASE_URL}/service-id/env-vars",
-    json=test_env_vars,
+    json=test_render_env_vars,
     status=200,
 )
 
@@ -118,3 +125,9 @@ test_env_var_key_pairs = [
     {"key": "key3", "value": "value3"},
     {"key": "key4", "value": "value4"},
 ]
+
+test_env_vars = {"key1": "value1", "key2": "value2", "key3": "value3", "key4": "value4"}
+
+test_file_with_comments = "test1=1\ntest2=2\n#test3=3\ntest4=4"
+
+test_dict_missing_commented_out_row = {"test1": "1", "test2": "2", "test4": "4"}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,33 @@
+"""Tests for utils.py."""
+from unittest import mock
+
+import render_cli.utils as utils
+from . import test_constants
+
+
+@mock.patch("os.path.isfile")
+def test_convert_env_var_file(mock_isfile):
+    """Tests converting env var file to dict."""
+    mock_isfile.return_value = True
+    file_data = mock.mock_open(read_data=test_constants.test_file_with_comments)
+    with mock.patch("render_cli.utils.open", file_data):
+        assert (
+            test_constants.test_dict_missing_commented_out_row
+            == utils.convert_env_var_file("any.txt")
+        )
+
+
+def test_convert_from_render_env_format():
+    """Tests converting render env output to dict."""
+    result = utils.convert_from_render_env_format(test_constants.test_render_env_vars)
+    assert result == test_constants.test_env_var_dict
+
+
+def test_convert_to_render_env_format():
+    """Tests converting dict render env format."""
+    assert (
+        utils.convert_to_render_env_format(
+            test_constants.test_env_vars,
+        )
+        == test_constants.test_env_var_key_pairs
+    )


### PR DESCRIPTION
The update flag allows for a merge of env vars already set and new ones in the env var file.  If values are present in both places then the value in the file overrides the value already set on the service.